### PR TITLE
PP-7760 Make TBB not segfault when compiled under GCC6.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -172,6 +172,13 @@ endif()
 if(CMAKE_COMPILER_IS_GNUCC)
   # Quench a warning on GCC
   set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/src/tbb/governor.cpp COMPILE_FLAGS "-Wno-missing-field-initializers ")
+  if (NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 6.0)
+    # TBB segfaults on GCC6. The TBB people say it's a GCC bug [1]. The GCC people say it's a TBB bug [2].
+    # [1]: https://software.intel.com/en-us/forums/intel-threading-building-blocks/topic/641654
+    # [2]: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=71388
+    # Both agree that the following flag is a good workaround:
+    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-lifetime-dse")
+  endif ()
 elseif(MSVC)
   # Quench a warning on MSVC
   set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/src/tbb/scheduler.cpp COMPILE_FLAGS "/wd4458 ")


### PR DESCRIPTION
Under GCC6, build TBB with the `-fno-lifetime-dse` flag.
